### PR TITLE
Add cert tech contacts

### DIFF
--- a/src/components/Routes/Certificates/OneCert/AddOneCert.tsx
+++ b/src/components/Routes/Certificates/OneCert/AddOneCert.tsx
@@ -109,6 +109,8 @@ type formObj = {
     post_processing_client_address: string;
     preferred_root_cn: string;
     profile: string | null;
+    tech_phone: string;
+    tech_email: string;
     organization: string;
     organizational_unit: string;
     country: string;
@@ -147,6 +149,8 @@ const AddOneCert: FC = () => {
         post_processing_client_address: '',
         preferred_root_cn: '',
         profile: null,
+        tech_phone: '',
+        tech_email: '',
         organization: '',
         organizational_unit: '',
         country: '',
@@ -401,6 +405,20 @@ const AddOneCert: FC = () => {
             value={formState.dataToSubmit.subject}
             onChange={inputChangeHandler}
             error={formState.validationErrors['dataToSubmit.subject']}
+          />
+
+          <InputTextField
+            id='dataToSubmit.tech_phone'
+            label='Technical Contact Phone Number'
+            value={formState.dataToSubmit.tech_phone}
+            onChange={inputChangeHandler}
+          />
+
+          <InputTextField
+            id='dataToSubmit.tech_email'
+            label='Technical Contact Email Address'
+            value={formState.dataToSubmit.tech_email}
+            onChange={inputChangeHandler}
           />
 
           <InputArrayText

--- a/src/components/Routes/Certificates/OneCert/EditOneCert.tsx
+++ b/src/components/Routes/Certificates/OneCert/EditOneCert.tsx
@@ -70,6 +70,8 @@ type formObj = {
     post_processing_client_address: string;
     preferred_root_cn: string;
     profile: string;
+		tech_phone: string;
+		tech_email: string;
     organization: string;
     organizational_unit: string;
     country: string;
@@ -129,6 +131,10 @@ const EditOneCert: FC = () => {
         private_key_id: certResponseData?.certificate.private_key.id ?? -1,
         subject_alts: certResponseData?.certificate.subject_alts ?? [],
         api_key_via_url: certResponseData?.certificate.api_key_via_url ?? false,
+        tech_phone:
+          certResponseData?.certificate.tech_phone ?? '',
+        tech_email:
+          certResponseData?.certificate.tech_email ?? '',
         post_processing_command:
           certResponseData?.certificate.post_processing_command ?? '',
         post_processing_environment:
@@ -506,6 +512,20 @@ const EditOneCert: FC = () => {
                 label='Subject (and Common Name)'
                 value={formState.getCertResponseData.certificate.subject}
                 disabled
+              />
+
+              <InputTextField
+                id='dataToSubmit.tech_phone'
+                label='Technical Contact Phone'
+                value={formState.dataToSubmit.tech_phone}
+                onChange={inputChangeHandler}
+              />
+
+              <InputTextField
+                id='dataToSubmit.tech_email'
+                label='Technical Contact Email Address'
+                value={formState.dataToSubmit.tech_email}
+                onChange={inputChangeHandler}
               />
 
               <InputArrayText

--- a/src/context/AuthProvider.tsx
+++ b/src/context/AuthProvider.tsx
@@ -4,7 +4,7 @@ import { type storedAuthorizationType, parseStoredAuthorizationType } from '../t
 import { createContext, useCallback, useEffect, useState } from 'react';
 
 // global idle logout timer
-let logoutTimer: number;
+let logoutTimer: undefined | ReturnType<typeof setTimeout>;
 
 const resetIdleLogoutTimer = (
   auth: storedAuthorizationType | undefined,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -649,6 +649,8 @@ const oneCertificateResponse = basicGoodResponse.extend({
     ),
     preferred_root_cn: z.string(),
     profile: z.string(),
+    tech_phone: z.string(),
+    tech_email: z.string(),
     api_key: z.string(),
     api_key_new: z.string().optional(),
     post_processing_command: z.string(),


### PR DESCRIPTION
This PR aims at adding two new fields to certificate entries, Technical Contact Telephone number and Technical Contact Email address.
In conjunction with [certwarden-backend PR#20](https://github.com/gregtwallace/certwarden-backend/pull/20), besides the informational character, these new fields are to be made available to the Post Script processing facility through the dynamic variables {{TECH_PHONE}} and {{TECH_EMAIL}}, making it easier to automate certificate distribution and notification to clients that don't have access to Certwarden's Web interface.