### PR TITLE
Add fuzzy search to Certificates and Private Keys list pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6719,6 +6719,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@mui/icons-material": "^6.5.0",
         "@mui/material": "^6.5.0",
         "axios": "^1.16.0",
+        "fuse.js": "^7.3.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-router": "^7.14.0",
@@ -4425,6 +4426,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
+      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
       }
     },
     "node_modules/generator-function": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@mui/icons-material": "^6.5.0",
     "@mui/material": "^6.5.0",
     "axios": "^1.16.0",
+    "fuse.js": "^7.3.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-router": "^7.14.0",

--- a/package.json
+++ b/package.json
@@ -42,5 +42,10 @@
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.58.1",
     "vite": "^6.4.2"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/src/components/Routes/Certificates/AllCertificates.tsx
+++ b/src/components/Routes/Certificates/AllCertificates.tsx
@@ -1,16 +1,16 @@
+import { type IFuseOptions } from 'fuse.js';
 import { type FC, useState } from 'react';
 import {
   type certificatesResponseType,
   parseCertificatesResponseType,
 } from '../../../types/api';
 import { type headerType } from '../../UI/TableMui/TableHeaderRow';
-import { type IFuseOptions } from 'fuse.js';
 
 import { Link as RouterLink, useSearchParams } from 'react-router';
 
+import { newId } from '../../../helpers/constants';
 import useAxiosGet from '../../../hooks/useAxiosGet';
 import { queryParser } from '../../UI/TableMui/query';
-import { newId } from '../../../helpers/constants';
 
 import Link from '@mui/material/Link';
 import Table from '@mui/material/Table';
@@ -19,19 +19,19 @@ import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 
-import ApiLoading from '../../UI/Api/ApiLoading';
+import useDebounce from '../../../hooks/useDebounce';
+import useFuseSearch from '../../../hooks/useFuseSearch';
 import ApiError from '../../UI/Api/ApiError';
+import ApiLoading from '../../UI/Api/ApiLoading';
 import ButtonAsLink from '../../UI/Button/ButtonAsLink';
 import DateWithTooltip from '../../UI/DateWithTooltip/DateWithTooltip';
 import FlagLegacyAPI from '../../UI/Flag/FlagLegacyAPI';
 import FlagStaging from '../../UI/Flag/FlagStaging';
 import TableContainer from '../../UI/TableMui/TableContainer';
 import TableHeaderRow from '../../UI/TableMui/TableHeaderRow';
+import TablePagination from '../../UI/TableMui/TablePagination';
 import TableSearch from '../../UI/TableMui/TableSearch';
 import TitleBar from '../../UI/TitleBar/TitleBar';
-import TablePagination from '../../UI/TableMui/TablePagination';
-import useDebounce from '../../../hooks/useDebounce';
-import useFuseSearch from '../../../hooks/useFuseSearch';
 
 const CERTIFICATES_URL = '/v1/certificates';
 

--- a/src/components/Routes/Certificates/AllCertificates.tsx
+++ b/src/components/Routes/Certificates/AllCertificates.tsx
@@ -1,9 +1,10 @@
-import { type FC } from 'react';
+import { type FC, useState } from 'react';
 import {
   type certificatesResponseType,
   parseCertificatesResponseType,
 } from '../../../types/api';
 import { type headerType } from '../../UI/TableMui/TableHeaderRow';
+import { type IFuseOptions } from 'fuse.js';
 
 import { Link as RouterLink, useSearchParams } from 'react-router';
 
@@ -26,10 +27,18 @@ import FlagLegacyAPI from '../../UI/Flag/FlagLegacyAPI';
 import FlagStaging from '../../UI/Flag/FlagStaging';
 import TableContainer from '../../UI/TableMui/TableContainer';
 import TableHeaderRow from '../../UI/TableMui/TableHeaderRow';
+import TableSearch from '../../UI/TableMui/TableSearch';
 import TitleBar from '../../UI/TitleBar/TitleBar';
 import TablePagination from '../../UI/TableMui/TablePagination';
+import useDebounce from '../../../hooks/useDebounce';
+import useFuseSearch from '../../../hooks/useFuseSearch';
 
 const CERTIFICATES_URL = '/v1/certificates';
+
+const fuseOptions: IFuseOptions<certificatesResponseType['certificates'][number]> = {
+  keys: ['name', 'subject', 'private_key.name', 'acme_account.name'],
+  threshold: 0.3,
+};
 
 // table headers and sortable param
 const tableHeaders: headerType[] = [
@@ -70,10 +79,35 @@ const AllCertificates: FC = () => {
   const [searchParams] = useSearchParams();
   const { page, rowsPerPage, queryParams } = queryParser(searchParams, 'name');
 
+  // fuzzy search state
+  const [searchTerm, setSearchTerm] = useState('');
+  const debouncedSearchTerm = useDebounce(searchTerm, 200);
+
+  // when search is active, fetch all records; otherwise use normal paginated fetch
+  const fetchUrl =
+    debouncedSearchTerm !== ''
+      ? `${CERTIFICATES_URL}?limit=0&sort=name.asc`
+      : `${CERTIFICATES_URL}?${queryParams}`;
+
   const { getState } = useAxiosGet<certificatesResponseType>(
-    `${CERTIFICATES_URL}?${queryParams}`,
+    fetchUrl,
     parseCertificatesResponseType
   );
+
+  const allCertificates = getState.responseData?.certificates ?? [];
+  const filteredCertificates = useFuseSearch(
+    allCertificates,
+    debouncedSearchTerm,
+    fuseOptions
+  );
+
+  const isSearchActive = debouncedSearchTerm !== '';
+  const displayedCertificates = isSearchActive
+    ? filteredCertificates.slice(page * rowsPerPage, (page + 1) * rowsPerPage)
+    : allCertificates;
+  const totalCount = isSearchActive
+    ? filteredCertificates.length
+    : (getState.responseData?.total_records ?? 0);
 
   return (
     <TableContainer>
@@ -85,6 +119,12 @@ const AllCertificates: FC = () => {
           New Certificate
         </ButtonAsLink>
       </TitleBar>
+
+      <TableSearch
+        value={searchTerm}
+        onChange={setSearchTerm}
+        {...(isSearchActive ? { resultCount: filteredCertificates.length } : {})}
+      />
 
       {!getState.responseData && !getState.error && <ApiLoading />}
 
@@ -102,7 +142,14 @@ const AllCertificates: FC = () => {
               <TableHeaderRow headers={tableHeaders} />
             </TableHead>
             <TableBody>
-              {getState.responseData.certificates.map((cert) => (
+              {displayedCertificates.length === 0 && isSearchActive && (
+                <TableRow>
+                  <TableCell colSpan={tableHeaders.length} align='center'>
+                    No certificates match &ldquo;{debouncedSearchTerm}&rdquo;
+                  </TableCell>
+                </TableRow>
+              )}
+              {displayedCertificates.map((cert) => (
                 <TableRow key={cert.id}>
                   <TableCell>
                     <Link
@@ -149,7 +196,7 @@ const AllCertificates: FC = () => {
           <TablePagination
             page={page}
             rowsPerPage={rowsPerPage}
-            count={getState.responseData.total_records}
+            count={totalCount}
           />
         </>
       )}

--- a/src/components/Routes/PrivateKeys/AllPrivateKeys.tsx
+++ b/src/components/Routes/PrivateKeys/AllPrivateKeys.tsx
@@ -1,37 +1,37 @@
+import { type IFuseOptions } from 'fuse.js';
 import { type FC, useState } from 'react';
 import {
   type privateKeysResponseType,
   parsePrivateKeysResponseType,
 } from '../../../types/api';
 import { type headerType } from '../../UI/TableMui/TableHeaderRow';
-import { type IFuseOptions } from 'fuse.js';
 
-import { Link as RouterLink, useSearchParams } from 'react-router';
 import { Link } from '@mui/material';
+import { Link as RouterLink, useSearchParams } from 'react-router';
 
+import { TableCell } from '@mui/material';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
-import { TableCell } from '@mui/material';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 
+import { newId } from '../../../helpers/constants';
 import useAxiosGet from '../../../hooks/useAxiosGet';
 import { queryParser } from '../../UI/TableMui/query';
-import { newId } from '../../../helpers/constants';
 
-import ApiLoading from '../../UI/Api/ApiLoading';
+import useDebounce from '../../../hooks/useDebounce';
+import useFuseSearch from '../../../hooks/useFuseSearch';
 import ApiError from '../../UI/Api/ApiError';
+import ApiLoading from '../../UI/Api/ApiLoading';
 import ButtonAsLink from '../../UI/Button/ButtonAsLink';
 import DateWithTooltip from '../../UI/DateWithTooltip/DateWithTooltip';
 import FlagAPIDisabled from '../../UI/Flag/FlagAPIDisabled';
 import FlagLegacyAPI from '../../UI/Flag/FlagLegacyAPI';
 import TableContainer from '../../UI/TableMui/TableContainer';
 import TableHeaderRow from '../../UI/TableMui/TableHeaderRow';
+import TablePagination from '../../UI/TableMui/TablePagination';
 import TableSearch from '../../UI/TableMui/TableSearch';
 import TitleBar from '../../UI/TitleBar/TitleBar';
-import TablePagination from '../../UI/TableMui/TablePagination';
-import useDebounce from '../../../hooks/useDebounce';
-import useFuseSearch from '../../../hooks/useFuseSearch';
 
 const PRIVATE_KEYS_URL = '/v1/privatekeys';
 

--- a/src/components/Routes/PrivateKeys/AllPrivateKeys.tsx
+++ b/src/components/Routes/PrivateKeys/AllPrivateKeys.tsx
@@ -1,9 +1,10 @@
-import { type FC } from 'react';
+import { type FC, useState } from 'react';
 import {
   type privateKeysResponseType,
   parsePrivateKeysResponseType,
 } from '../../../types/api';
 import { type headerType } from '../../UI/TableMui/TableHeaderRow';
+import { type IFuseOptions } from 'fuse.js';
 
 import { Link as RouterLink, useSearchParams } from 'react-router';
 import { Link } from '@mui/material';
@@ -26,10 +27,18 @@ import FlagAPIDisabled from '../../UI/Flag/FlagAPIDisabled';
 import FlagLegacyAPI from '../../UI/Flag/FlagLegacyAPI';
 import TableContainer from '../../UI/TableMui/TableContainer';
 import TableHeaderRow from '../../UI/TableMui/TableHeaderRow';
+import TableSearch from '../../UI/TableMui/TableSearch';
 import TitleBar from '../../UI/TitleBar/TitleBar';
 import TablePagination from '../../UI/TableMui/TablePagination';
+import useDebounce from '../../../hooks/useDebounce';
+import useFuseSearch from '../../../hooks/useFuseSearch';
 
 const PRIVATE_KEYS_URL = '/v1/privatekeys';
+
+const fuseOptions: IFuseOptions<privateKeysResponseType['private_keys'][number]> = {
+  keys: ['name', 'description', 'algorithm.name'],
+  threshold: 0.3,
+};
 
 // table headers and sortable param
 const tableHeaders: headerType[] = [
@@ -65,10 +74,31 @@ const AllPrivateKeys: FC = () => {
   const [searchParams] = useSearchParams();
   const { page, rowsPerPage, queryParams } = queryParser(searchParams, 'name');
 
+  // fuzzy search state
+  const [searchTerm, setSearchTerm] = useState('');
+  const debouncedSearchTerm = useDebounce(searchTerm, 200);
+
+  // when search is active, fetch all records; otherwise use normal paginated fetch
+  const fetchUrl =
+    debouncedSearchTerm !== ''
+      ? `${PRIVATE_KEYS_URL}?limit=0&sort=name.asc`
+      : `${PRIVATE_KEYS_URL}?${queryParams}`;
+
   const { getState } = useAxiosGet<privateKeysResponseType>(
-    `${PRIVATE_KEYS_URL}?${queryParams}`,
+    fetchUrl,
     parsePrivateKeysResponseType
   );
+
+  const allKeys = getState.responseData?.private_keys ?? [];
+  const filteredKeys = useFuseSearch(allKeys, debouncedSearchTerm, fuseOptions);
+
+  const isSearchActive = debouncedSearchTerm !== '';
+  const displayedKeys = isSearchActive
+    ? filteredKeys.slice(page * rowsPerPage, (page + 1) * rowsPerPage)
+    : allKeys;
+  const totalCount = isSearchActive
+    ? filteredKeys.length
+    : (getState.responseData?.total_records ?? 0);
 
   return (
     <TableContainer>
@@ -78,6 +108,12 @@ const AllPrivateKeys: FC = () => {
       >
         <ButtonAsLink to={`/privatekeys/${newId.toString()}`}>New Key</ButtonAsLink>
       </TitleBar>
+
+      <TableSearch
+        value={searchTerm}
+        onChange={setSearchTerm}
+        {...(isSearchActive ? { resultCount: filteredKeys.length } : {})}
+      />
 
       {!getState.responseData && !getState.error && <ApiLoading />}
 
@@ -95,7 +131,14 @@ const AllPrivateKeys: FC = () => {
               <TableHeaderRow headers={tableHeaders} />
             </TableHead>
             <TableBody>
-              {getState.responseData.private_keys.map((key) => (
+              {displayedKeys.length === 0 && isSearchActive && (
+                <TableRow>
+                  <TableCell colSpan={tableHeaders.length} align='center'>
+                    No keys match &ldquo;{debouncedSearchTerm}&rdquo;
+                  </TableCell>
+                </TableRow>
+              )}
+              {displayedKeys.map((key) => (
                 <TableRow key={key.id}>
                   <TableCell>
                     <Link component={RouterLink} to={'/privatekeys/' + key.id.toString()}>
@@ -118,7 +161,7 @@ const AllPrivateKeys: FC = () => {
           <TablePagination
             page={page}
             rowsPerPage={rowsPerPage}
-            count={getState.responseData.total_records}
+            count={totalCount}
           />
         </>
       )}

--- a/src/components/UI/TableMui/TableSearch.tsx
+++ b/src/components/UI/TableMui/TableSearch.tsx
@@ -1,0 +1,66 @@
+import { type ChangeEvent, type FC } from 'react';
+
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import InputAdornment from '@mui/material/InputAdornment';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import ClearIcon from '@mui/icons-material/Clear';
+import SearchIcon from '@mui/icons-material/Search';
+
+type propTypes = {
+  value: string;
+  onChange: (newValue: string) => void;
+  resultCount?: number;
+  placeholder?: string;
+};
+
+const TableSearch: FC<propTypes> = (props) => {
+  const { onChange, placeholder = 'Search…', resultCount, value } = props;
+
+  const changeHandler = (event: ChangeEvent<HTMLInputElement>): void => {
+    onChange(event.target.value);
+  };
+
+  const clearHandler = (): void => {
+    onChange('');
+  };
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', mb: 1, gap: 1 }}>
+      <TextField
+        size='small'
+        value={value}
+        onChange={changeHandler}
+        placeholder={placeholder}
+        slotProps={{
+          input: {
+            startAdornment: (
+              <InputAdornment position='start'>
+                <SearchIcon fontSize='small' />
+              </InputAdornment>
+            ),
+            endAdornment: value !== '' && (
+              <InputAdornment position='end'>
+                <IconButton
+                  size='small'
+                  onClick={clearHandler}
+                  aria-label='clear search'
+                >
+                  <ClearIcon fontSize='small' />
+                </IconButton>
+              </InputAdornment>
+            ),
+          },
+        }}
+      />
+      {value !== '' && resultCount !== undefined && (
+        <Typography variant='caption' color='text.secondary'>
+          {resultCount} result{resultCount !== 1 ? 's' : ''}
+        </Typography>
+      )}
+    </Box>
+  );
+};
+
+export default TableSearch;

--- a/src/components/UI/TableMui/TableSearch.tsx
+++ b/src/components/UI/TableMui/TableSearch.tsx
@@ -1,12 +1,12 @@
 import { type ChangeEvent, type FC } from 'react';
 
+import ClearIcon from '@mui/icons-material/Clear';
+import SearchIcon from '@mui/icons-material/Search';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import ClearIcon from '@mui/icons-material/Clear';
-import SearchIcon from '@mui/icons-material/Search';
 
 type propTypes = {
   value: string;

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+const useDebounce = <T>(value: T, delay: number): T => {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+};
+
+export default useDebounce;

--- a/src/hooks/useFuseSearch.ts
+++ b/src/hooks/useFuseSearch.ts
@@ -1,0 +1,20 @@
+import { useMemo } from 'react';
+import Fuse, { type IFuseOptions } from 'fuse.js';
+
+const useFuseSearch = <T>(
+  data: T[],
+  searchTerm: string,
+  options: IFuseOptions<T>
+): T[] => {
+  const fuse = useMemo(() => new Fuse(data, options), [data, options]);
+
+  return useMemo(() => {
+    if (searchTerm === '') {
+      return data;
+    }
+
+    return fuse.search(searchTerm).map((result) => result.item);
+  }, [fuse, data, searchTerm]);
+};
+
+export default useFuseSearch;

--- a/src/hooks/useFuseSearch.ts
+++ b/src/hooks/useFuseSearch.ts
@@ -1,5 +1,5 @@
-import { useMemo } from 'react';
 import Fuse, { type IFuseOptions } from 'fuse.js';
+import { useMemo } from 'react';
 
 const useFuseSearch = <T>(
   data: T[],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
+import { defineConfig } from 'vite';
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Add fuzzy search to Certificates and Private Keys list pages

Adds a search input above each list that dynamically filters results using [Fuse.js](https://www.fusejs.io/) fuzzy matching.

Certificates — searches across name, subject, private_key.name, acme_account.name
Private Keys — searches across name, description, algorithm.name

When a search term is active, the page fetches all records (limit=0) and filters client-side. Pagination and sorting are preserved. An empty-state row is shown when no results match.

New files: useDebounce, useFuseSearch hooks, TableSearch UI component
Dependency added: fuse.js